### PR TITLE
fixed publish workflow running in any branch and permission issues

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,15 @@
 name: Publish
 on:
   workflow_run:
-    workflows: ["CI"]
-    types:
-      - completed
-  push:
-    branches:
-      - "main"
+    workflows: [CI]
+    branches: [main]
+    types: [completed]
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   publish:


### PR DESCRIPTION
First of all, I want to thank you for your amazing video. It was very helpful.

However I ran into someone issues while following along.

First issue I faced was related to permission. I managed to fix it by specifying the required permissions in `publish.yml` file and granting pull request permission in repository settings.

The second issue I faced is that the `publish` workflow always gets triggered even though changes are not made in the main branch. The reason was `Publish` workflow gets triggered every time the `CI` workflow succeeds, but the `CI` workflow is triggered from **any** branches. 

To fix that, I have added `branches` property to the `workflow_run` event.

And also, I have removed the `push` event because it was getting skipped because of the if statement. This event is no longer necessary since we have `workflow_run` event.